### PR TITLE
support "context" as an alias of "describe"

### DIFF
--- a/lib/mocha-gwt.coffee
+++ b/lib/mocha-gwt.coffee
@@ -39,14 +39,19 @@ mochaGWT = (suite) ->
       fn.apply(@)
       context.currentBlock = lastAtDepth[--depth]
 
-    global.describe = addBlock
+    global.describe =
+    global.context = addBlock
 
     global.describe.skip =
-    global.xdescribe = (title, fn) ->
+    global.xdescribe =
+    global.context.skip =
+    global.xcontext = (title, fn) ->
       addBlock title, fn, pending: true
 
     global.describe.only =
-    global.ddescribe = (title, fn) ->
+    global.ddescribe =
+    global.context.only =
+    global.ccontext = (title, fn) ->
       addBlock title, fn, only: true
       onlyFound = true
 

--- a/test/e2e/mocha-gwt-test.coffee
+++ b/test/e2e/mocha-gwt-test.coffee
@@ -86,4 +86,9 @@ describe 'mocha-gwt', ->
     describe 'after should have been called', ->
       Then -> foo == 2
 
-
+  describe 'aliases', ->
+    Then -> global.context == describe
+    Then -> global.context.skip == describe.skip
+    And  -> global.xcontext == describe.skip
+    Then -> global.context.only == describe.only
+    And  -> global.ccontext == describe.only


### PR DESCRIPTION
Adds corresponding `context` aliases of `describe` and its variants:

* `context` ← `describe`
* `context.skip` ← `xcontext` ← `describe.skip`
* `context.only` ← `ccontext` ← `describe.only`

Fixes #5