### PR TITLE
Browserify

### DIFF
--- a/lib/mocha-gwt.coffee
+++ b/lib/mocha-gwt.coffee
@@ -22,7 +22,7 @@ mochaGWT = (suite) ->
   determineSkip = (block) ->
     block.pending == true || (onlyFound && !block.only)
 
-  suite.on 'pre-require', (context, file, mocha) ->
+  suite.on 'pre-require', (context, file='browser', mocha) ->
     depth = 0
     context.currentBlock = null
     lastAtDepth = {}
@@ -68,7 +68,7 @@ mochaGWT = (suite) ->
 
     context.afterBlock = (fn) -> context.currentBlock.afterBlocks.push fn
 
-  suite.on 'post-require', (context, file, mocha) ->
+  suite.on 'post-require', (context, file='browser', mocha) ->
     processedFiles.push file
     fileParents[file] = Suite.create suite, ''
 

--- a/lib/mocha-gwt.coffee
+++ b/lib/mocha-gwt.coffee
@@ -106,10 +106,9 @@ mochaGWT = (suite) ->
           test.pending = shouldSkip
           s.addTest test
 
-    if processedFiles.length == mocha.files.length
-      processedFiles.forEach (f) ->
-        blockList[f].forEach (block) ->
-          buildMochaSuite block, f
+    processedFiles.forEach (f) ->
+      blockList[f].forEach (block) ->
+        buildMochaSuite block, f
 
     beforeAlls[file].forEach (fn) ->
       fileParents[file].beforeAll fn unless determineSkip blockList[file][0]

--- a/lib/mocha-gwt.coffee
+++ b/lib/mocha-gwt.coffee
@@ -106,15 +106,17 @@ mochaGWT = (suite) ->
           test.pending = shouldSkip
           s.addTest test
 
-    processedFiles.forEach (f) ->
-      blockList[f].forEach (block) ->
-        buildMochaSuite block, f
+    if processedFiles.length == mocha.files.length || isInBrowser(mocha)
+      processedFiles.forEach (f) ->
+        blockList[f].forEach (block) ->
+          buildMochaSuite block, f
 
     beforeAlls[file].forEach (fn) ->
       fileParents[file].beforeAll fn unless determineSkip blockList[file][0]
     afterAlls[file].forEach (fn) ->
       fileParents[file].afterAll fn unless determineSkip blockList[file][0]
 
+isInBrowser = (mocha) -> mocha.files.length == 0
 
 module.exports = mochaGWT
 Mocha.interfaces['mocha-gwt'] = mochaGWT

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "version": "0.2.1",
   "description": "Given When Then for Mocha",
   "main": "index.js",
+  "browser": "lib/mocha-gwt.coffee",
   "scripts": {
     "prepublish": "npm test",
     "test": "npm run unit && npm run e2e",
     "unit": "mocha test/unit/",
     "e2e": "coffee runtest.coffee",
-    "build": "browserify --extension=.coffee --outfile gwt.js lib/mocha-gwt"
+    "build": "browserify $npm_package_main --extension=.coffee --outfile gwt.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "npm run unit && npm run e2e",
     "unit": "mocha test/unit/",
     "e2e": "coffee runtest.coffee",
-    "build": "browserify $npm_package_main --extension=.coffee -o $npm_package_config_build_file"
+    "build": "browserify . --extension=.coffee -o $npm_package_config_build_file"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "prepublish": "npm test",
     "test": "npm run unit && npm run e2e",
     "unit": "mocha test/unit/",
-    "e2e": "coffee runtest.coffee"
+    "e2e": "coffee runtest.coffee",
+    "build": "browserify --extension=.coffee --outfile gwt.js --exclude mocha lib/mocha-gwt"
   },
   "repository": {
     "type": "git",
@@ -20,7 +21,9 @@
   },
   "devDependencies": {
     "bluebird": "^2.3.5",
+    "browserify": "^11.0.1",
     "chai": "^3.0.0",
+    "coffeeify": "^1.1.0",
     "mocha": "^2.0.0",
     "nodemon": "^1.4.1"
   },
@@ -28,5 +31,10 @@
     "assertion-error": "^1.0.0",
     "coffee-script": "^1.7.1",
     "ramda": "^0.17.1"
+  },
+  "browserify": {
+    "transform": [
+      "coffeeify"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "description": "Given When Then for Mocha",
   "main": "index.js",
   "browser": "lib/mocha-gwt.coffee",
+  "config": {
+    "build_file": "dist/mocha-gwt.js"
+  },
   "scripts": {
     "prepublish": "npm test",
     "test": "npm run unit && npm run e2e",
     "unit": "mocha test/unit/",
     "e2e": "coffee runtest.coffee",
-    "build": "browserify $npm_package_main --extension=.coffee --outfile gwt.js"
+    "build": "browserify $npm_package_main --extension=.coffee -o $npm_package_config_build_file"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     ]
   },
   "browserify-shim": {
-    "mocha": "global:mocha"
+    "mocha": "global:Mocha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npm run unit && npm run e2e",
     "unit": "mocha test/unit/",
     "e2e": "coffee runtest.coffee",
-    "build": "browserify --extension=.coffee --outfile gwt.js --exclude mocha lib/mocha-gwt"
+    "build": "browserify --extension=.coffee --outfile gwt.js lib/mocha-gwt"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "bluebird": "^2.3.5",
     "browserify": "^11.0.1",
+    "browserify-shim": "^3.8.10",
     "chai": "^3.0.0",
     "coffeeify": "^1.1.0",
     "mocha": "^2.0.0",
@@ -34,7 +35,11 @@
   },
   "browserify": {
     "transform": [
-      "coffeeify"
+      "coffeeify",
+      "browserify-shim"
     ]
+  },
+  "browserify-shim": {
+    "mocha": "global:mocha"
   }
 }


### PR DESCRIPTION
# do not merge

There are multiple components to this PR, and some of them will be extracted as separate PRs (since some changes aren't specific to browser functionality)
- the ui methods should be attached to the provided suite context, not `global` (this can be a separate PR. it is a standalone change)
- the `pre-require` and `post-require` events are given a `null` value for `file` when invoked in the browser, so a default dummy value of `'browser'` is used
- the `processedFiles.length` guard will not work in the browser since `mocha.files` will be empty. However, I'm not sure of the purpose of this guard in node, so some alternative is necessary before this can be merged. For now, I've simply removed the guard and allowed each `processedFile` to be built into a mocha suite.
- this PR requires that the `post-require` hook be invoked manually just prior to `mocha.run()`. For my testing, I have configured this manually, but I now have an [open PR to Mocha](https://github.com/mochajs/mocha/pull/1905) which will do this automatically in the browser-distribution of mocha
- browserify is required and configured via an npm script (`npm run build`) which drops the browser-build under `/dist` (this dist file will either need to be included in the npm tarball on prepublish, or committed in github, or published to github as a release asset. I can configure another PR that does this automatically whenever a new version is released)
- coffeeify transform is configured for browserify to compile coffee into JS during the build step
- browserify-shim transform is included such that the `require('mocha')` call is replaced with a `window.Mocha` shim. It should be assumed that if mocha-gwt is being used in the browser that mocha is included like a regular script and exists as the global `Mocha` (which is [indeed what is done in the browser distribution](https://github.com/mochajs/mocha/blob/c4393c456839d6bf2cbb4abb1cd177010ee06458/support/browser-entry.js#L160) of mocha)
